### PR TITLE
Update VBE_DISPI_NDEX_VIDEO_MEMORY_64KB documentation

### DIFF
--- a/vgabios/vbe_display_api.txt
+++ b/vgabios/vbe_display_api.txt
@@ -100,16 +100,17 @@ vbe.h
   #define VBE_DISPI_IOPORT_INDEX          0x01CE
   #define VBE_DISPI_IOPORT_DATA           0x01CF
 
-  #define VBE_DISPI_INDEX_ID              0x0
-  #define VBE_DISPI_INDEX_XRES            0x1
-  #define VBE_DISPI_INDEX_YRES            0x2
-  #define VBE_DISPI_INDEX_BPP             0x3
-  #define VBE_DISPI_INDEX_ENABLE          0x4
-  #define VBE_DISPI_INDEX_BANK            0x5
-  #define VBE_DISPI_INDEX_VIRT_WIDTH      0x6
-  #define VBE_DISPI_INDEX_VIRT_HEIGHT     0x7
-  #define VBE_DISPI_INDEX_X_OFFSET        0x8
-  #define VBE_DISPI_INDEX_Y_OFFSET        0x9
+  #define VBE_DISPI_INDEX_ID                0x0
+  #define VBE_DISPI_INDEX_XRES              0x1
+  #define VBE_DISPI_INDEX_YRES              0x2
+  #define VBE_DISPI_INDEX_BPP               0x3
+  #define VBE_DISPI_INDEX_ENABLE            0x4
+  #define VBE_DISPI_INDEX_BANK              0x5
+  #define VBE_DISPI_INDEX_VIRT_WIDTH        0x6
+  #define VBE_DISPI_INDEX_VIRT_HEIGHT       0x7
+  #define VBE_DISPI_INDEX_X_OFFSET          0x8
+  #define VBE_DISPI_INDEX_Y_OFFSET          0x9
+  #define VBE_DISPI_INDEX_VIDEO_MEMORY_64K  0xa
 
   #define VBE_DISPI_ID0                   0xB0C0
   #define VBE_DISPI_ID1                   0xB0C1
@@ -217,7 +218,10 @@ API
 
 [0xb0c5]
   * VBE video memory increased to 16 MB.
-  * Video memory size stored in new register VBE_DISPI_INDEX_VIDEO_MEMORY_64K.
+  * VBE_DISPI_INDEX_VIDEO_MEMORY_64K : WORD {R}
+    Video memory size, divided by 64KB.
+
+    Example value: 256 (16MB)
 
 Displaying GFX (banked mode)
 --------------


### PR DESCRIPTION
This PR updates the documentation for the VBE_DISPI_NDEX_VIDEO_MEMORY_64KB register in vbe_display_api.txt to more closely match the documentation format for the other registers.