### PR TITLE
Bochs VBE: vbebios_vsync_wait now waits (fixes #7)

### DIFF
--- a/vgabios/vgabios.c
+++ b/vgabios/vgabios.c
@@ -4994,6 +4994,10 @@ vbe_get_dac_loop:
 vbebios_vsync_wait:
   push dx
   mov  dx, #VGAREG_ACTL_RESET
+vbebios_in_vsync:
+  in   al, dx
+  test al, #0x08
+  jnz  vbebios_in_vsync
 vbebios_wait_loop:
   in   al, dx
   test al, #0x08


### PR DESCRIPTION
There is a bug in vbebios_vsync_wait where it only checks to see we are
 currently in vsync instead of waiting for the transition into vsync.
This patch makes it so repeated calls to VBE Function 07h to set the
 display start will now display a single frame during vertical retrace.