### PR TITLE
Improved the VESA3 protected mode support for Cirrus.

### DIFF
--- a/vgabios/Makefile
+++ b/vgabios/Makefile
@@ -18,14 +18,15 @@ RELVERS = `pwd | sed "s-.*/--" | sed "s/vgabios//" | sed "s/-//"`
 
 VGABIOS_DATE = "-DVGABIOS_DATE=\"$(RELDATE)\""
 RELEASE_BIN_LIST=README VGABIOS-lgpl-latest.bin VGABIOS-lgpl-latest-debug.bin \
-                 VGABIOS-lgpl-latest-cirrus.bin VGABIOS-lgpl-latest-cirrus-debug.bin \
+                 VGABIOS-lgpl-latest-cirrus.bin VGABIOS-lgpl-latest-cirrus-vesa3.bin \
+				 VGABIOS-lgpl-latest-cirrus-debug.bin \
                  VGABIOS-lgpl-latest-banshee.bin VGABIOS-lgpl-latest-banshee-debug.bin
 
 all: bios cirrus-bios banshee-bios
 
 bios: vgabios.bin vgabios.debug.bin
 
-cirrus-bios: vgabios-cirrus.bin vgabios-cirrus.debug.bin
+cirrus-bios: vgabios-cirrus.bin vgabios-cirrus.vesa3.bin vgabios-cirrus.debug.bin
 
 banshee-bios: vgabios-banshee.bin vgabios-banshee.debug.bin
 
@@ -38,12 +39,14 @@ dist-clean: clean
 # source files
 VGA_FILES := vgabios.c vgabios.h vgafonts.h vgatables.h
 VBE_FILES := vbe.h vbe.c
+CIRRUS_FILES := clext.c
 BANSHEE_FILES := banshee.c
 
 # build flags
 vgabios.bin              : VGAFLAGS := -DVBE -DPCIBIOS
 vgabios.debug.bin        : VGAFLAGS := -DVBE -DPCIBIOS -DDEBUG
 vgabios-cirrus.bin       : VGAFLAGS := -DCIRRUS -DPCIBIOS
+vgabios-cirrus.vesa3.bin : VGAFLAGS := -DCIRRUS -DPCIBIOS -DCIRRUS_VESA3_PMINFO
 vgabios-cirrus.debug.bin : VGAFLAGS := -DCIRRUS -DPCIBIOS -DCIRRUS_DEBUG
 vgabios-banshee.bin      : VGAFLAGS := -DBANSHEE -DPCIBIOS
 vgabios-banshee.debug.bin : VGAFLAGS := -DBANSHEE -DPCIBIOS -DBANSHEE_DEBUG
@@ -52,6 +55,7 @@ vgabios-banshee.debug.bin : VGAFLAGS := -DBANSHEE -DPCIBIOS -DBANSHEE_DEBUG
 vgabios.bin              : DISTNAME := VGABIOS-lgpl-latest.bin
 vgabios.debug.bin        : DISTNAME := VGABIOS-lgpl-latest-debug.bin
 vgabios-cirrus.bin       : DISTNAME := VGABIOS-lgpl-latest-cirrus.bin
+vgabios-cirrus.vesa3.bin : DISTNAME := VGABIOS-lgpl-latest-cirrus-vesa3.bin
 vgabios-cirrus.debug.bin : DISTNAME := VGABIOS-lgpl-latest-cirrus-debug.bin
 vgabios-banshee.bin      : DISTNAME := VGABIOS-lgpl-latest-banshee.bin
 vgabios-banshee.debug.bin : DISTNAME := VGABIOS-lgpl-latest-banshee-debug.bin
@@ -59,10 +63,11 @@ vgabios-banshee.debug.bin : DISTNAME := VGABIOS-lgpl-latest-banshee-debug.bin
 # dependencies
 vgabios.bin              : $(VGA_FILES) $(VBE_FILES) biossums
 vgabios.debug.bin        : $(VGA_FILES) $(VBE_FILES) biossums
-vgabios-cirrus.bin       : $(VGA_FILES) clext.c biossums
-vgabios-cirrus.debug.bin : $(VGA_FILES) clext.c biossums
-vgabios-banshee.bin      : $(VGA_FILES) banshee.c biossums
-vgabios-banshee.debug.bin : $(VGA_FILES) banshee.c biossums
+vgabios-cirrus.bin       : $(VGA_FILES) $(CIRRUS_FILES) biossums
+vgabios-cirrus.vesa3.bin : $(VGA_FILES) $(CIRRUS_FILES) biossums
+vgabios-cirrus.debug.bin : $(VGA_FILES) $(CIRRUS_FILES) biossums
+vgabios-banshee.bin      : $(VGA_FILES) $(BANSHEE_FILES) biossums
+vgabios-banshee.debug.bin : $(VGA_FILES) $(BANSHEE_FILES) biossums
 
 # build rule
 %.bin:

--- a/vgabios/vgabios.c
+++ b/vgabios/vgabios.c
@@ -127,7 +127,12 @@ ASM_START
 
 MACRO SET_INT_VECTOR
   push ds
+#ifndef CIRRUS_VESA3_PMINFO
+  seg cs
+  mov ax, [cirrus_vesa_sel0000_data]
+#else
   xor ax, ax
+#endif
   mov ds, ax
   mov ax, ?3
   mov ?1*4, ax
@@ -4969,7 +4974,12 @@ strcpy:
   push cx
   push ds
   push di
+#ifdef CIRRUS_VESA3_PMINFO
+  seg cs
+  mov  ax, [cirrus_vesa_selC000_data]
+#else
   mov  ax, cs
+#endif
   mov  ds, ax
   xor  cx, cx
 strcpy_loop:

--- a/vgabios/vgabios.c
+++ b/vgabios/vgabios.c
@@ -127,7 +127,7 @@ ASM_START
 
 MACRO SET_INT_VECTOR
   push ds
-#ifndef CIRRUS_VESA3_PMINFO
+#ifdef CIRRUS_VESA3_PMINFO
   seg cs
   mov ax, [cirrus_vesa_sel0000_data]
 #else


### PR DESCRIPTION
Added a third version of the Cirrus BIOS, which exposes a protected mode interface, according to the VBE 3.0 standard. The VbeInfoBlock still advertises itself as VESA 2.0, and VBE 3.0-specific mode information is not returned by function 0x4F01.

Updated the code and verified that functions 0x4F00 (VBE Controller Info), 0x4F01 (VBE Mode Information) and 0x4F02 (Set VBE Mode) work correctly in 32-bit protected mode (under QEmu), using only the segment descriptors passed by the caller through the PMInfoBlock. The other functions should work.